### PR TITLE
Use wcsaxes from astropy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,11 +50,11 @@ matrix:
         # plot_directive in sphinx needs them
         - os: linux
           env: PYTHON_VERSION=2.7 SETUP_CMD='build_sphinx -w'
-               CONDA_DEPENDENCIES='pytz matplotlib nose wcsaxes astroquery'
+               CONDA_DEPENDENCIES='pytz matplotlib nose astroquery'
                PIP_DEPENDENCIES='pytest-mpl'
         - os: linux
           env: PYTHON_VERSION=3.5 SETUP_CMD='build_sphinx -w'
-               CONDA_DEPENDENCIES='pytz matplotlib nose wcsaxes astroquery'
+               CONDA_DEPENDENCIES='pytz matplotlib nose astroquery'
                PIP_DEPENDENCIES='pytest-mpl'
 
         # Try all python versions with the latest numpy

--- a/astroplan/plots/finder.py
+++ b/astroplan/plots/finder.py
@@ -73,7 +73,7 @@ def plot_finder_image(target, survey='DSS', fov_radius=10*u.arcmin,
     Notes
     -----
     Dependencies:
-        In addition to Matplotlib, this function makes use of astroquery and WCSAxes.
+        In addition to Matplotlib, this function makes use of astroquery.
     """
 
     import matplotlib.pyplot as plt

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -14,13 +14,12 @@ It requires Python 2.7 or 3.5+ (2.6 and 3.2 or earlier are not
 supported, 3.3 and 3.4 may work) as well as the following packages:
 
 * `Numpy`_
-* `Astropy`_ (v1.2 or later)
+* `Astropy`_ (v1.3 or later)
 * `pytz`_
 
 Optional packages:
 
 * `Matplotlib`_
-* `WCSAxes`_
 * `astroquery`_
 
 First-time Python users may want to consider an all-in-one Python installation

--- a/docs/references.txt
+++ b/docs/references.txt
@@ -6,5 +6,4 @@
 .. _pytz: https://pypi.python.org/pypi/pytz/
 .. _pytest-mpl: https://pypi.python.org/pypi/pytest-mpl
 .. _Nose: https://nose.readthedocs.io
-.. _WCSAxes: https://wcsaxes.readthedocs.io
 .. _astroquery: https://astroquery.readthedocs.io

--- a/docs/rtd-pip-requirements
+++ b/docs/rtd-pip-requirements
@@ -1,8 +1,7 @@
 numpy >= 1.6
 matplotlib
 Cython
-astropy-helpers
-astropy >= 1.2
+astropy >= 1.3
 pytz
 astroquery
-wcsaxes
+

--- a/docs/tutorials/plots.rst
+++ b/docs/tutorials/plots.rst
@@ -1121,9 +1121,8 @@ Finder Chart/Image
 `astroplan` includes a function for generating quick finder images from
 Python, `~astroplan.plots.plot_finder_image`, by querying for images from
 sky surveys centered on a `~astroplan.FixedTarget`. This function depends on
-`astroquery`_  (in addition
-to `Matplotlib`_ and `WCSAxes`_). In this example, we'll quickly make a finder image centered
-on The Crab Nebula (M1):
+`astroquery`_ (in addition to `Matplotlib`_). In this example, we'll quickly
+make a finder image centered on The Crab Nebula (M1):
 
 .. code-block:: python
 


### PR DESCRIPTION
This PR makes a bit of cleanup to remove mentioning of wcsaxes, as it's part of astropy 1.3 now. Also adds the requirement for astropy 1.3 everywhere.